### PR TITLE
perf: cache player after sending client brand to backend && fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.4.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <artifactSet>
@@ -33,6 +33,7 @@
                             <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                             <include>org.jetbrains.kotlin:kotlin-stdlib-common</include>
                             <include>org.bstats:*</include>
+                            <include>com.github.ben-manes.caffeine:caffeine</include>
                         </includes>
                     </artifactSet>
                     <relocations>
@@ -63,6 +64,10 @@
                         <relocation>
                             <pattern>org.bstats</pattern>
                             <shadedPattern>io.v4guard.shaded.org.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.github.ben-manes.caffeine</pattern>
+                            <shadedPattern>io.v4guard.shaded.com.github.ben-manes.caffeine</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -106,7 +111,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.0.1</version>
+            <version>3.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -162,6 +167,10 @@
             <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.6</version>
+        </dependency>
     </dependencies>
-
 </project>

--- a/src/main/java/io/v4guard/plugin/bungee/listener/AntiVPNListener.java
+++ b/src/main/java/io/v4guard/plugin/bungee/listener/AntiVPNListener.java
@@ -1,6 +1,7 @@
 package io.v4guard.plugin.bungee.listener;
 
 import io.v4guard.plugin.core.v4GuardCore;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.PreLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -18,6 +19,12 @@ public class AntiVPNListener implements Listener {
     public void onPostLogin(PostLoginEvent e) {
         v4GuardCore.getInstance().getCheckManager().runPostLoginCheck(e.getPlayer().getName(), e);
     }
+
+    @EventHandler
+    public void onPlayerDisconnect(PlayerDisconnectEvent event) {
+        v4GuardCore.getInstance().getBrandCheckManager().removePlayer(event.getPlayer().getUniqueId());
+    }
+
 
 //    @EventHandler(priority = Byte.MIN_VALUE)
 //    public void onChat(ChatEvent e) {

--- a/src/main/java/io/v4guard/plugin/bungee/listener/AntiVPNListener.java
+++ b/src/main/java/io/v4guard/plugin/bungee/listener/AntiVPNListener.java
@@ -1,7 +1,6 @@
 package io.v4guard.plugin.bungee.listener;
 
 import io.v4guard.plugin.core.v4GuardCore;
-import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.PreLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
@@ -18,11 +17,6 @@ public class AntiVPNListener implements Listener {
     @EventHandler(priority = Byte.MIN_VALUE)
     public void onPostLogin(PostLoginEvent e) {
         v4GuardCore.getInstance().getCheckManager().runPostLoginCheck(e.getPlayer().getName(), e);
-    }
-
-    @EventHandler
-    public void onPlayerDisconnect(PlayerDisconnectEvent event) {
-        v4GuardCore.getInstance().getBrandCheckManager().removePlayer(event.getPlayer().getUniqueId());
     }
 
 

--- a/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
+++ b/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
@@ -38,30 +38,32 @@ public class PluginMessagingListener implements Listener {
         ProxiedPlayer player = (ProxiedPlayer) e.getSender();
         if (v4GuardBungee.getCoreInstance().getBrandCheckManager().isPlayerAlreadyChecked(player.getUniqueId()) && !TEMP_CACHE.asMap().containsKey(player.getUniqueId())) return;
 
-        Document privacySettings = (Document) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("privacy", new Document());
-        boolean invalidatedCache = (boolean) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("invalidateCache", false);
+        if (e.getTag().equals("MC|Brand") || e.getTag().equals("minecraft:brand") || e.getTag().equals("LMC") || e.getTag().equals("labymod3:main")) {
+            Document privacySettings = (Document) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("privacy", new Document());
+            boolean invalidatedCache = (boolean) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("invalidateCache", false);
 
-        if (invalidatedCache && !privacySettings.getBoolean("collectMCBrand", true)) return;
+            if (invalidatedCache && !privacySettings.getBoolean("collectMCBrand", true)) return;
 
-        CompletableMCBrandTask task = v4GuardBungee.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getName());
-        if (task == null) task = new CompletableMCBrandTask(player.getName());
+            CompletableMCBrandTask task = v4GuardBungee.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getName());
+            if (task == null) task = new CompletableMCBrandTask(player.getName());
 
-        if (e.getTag().equals("MC|Brand") || e.getTag().equals("minecraft:brand")) {
-            task.addData(new String(e.getData()));
-        } else if (e.getTag().equals("LMC") || e.getTag().equals("labymod3:main")) {
-            ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
-            String key = StringUtils.readString(buf, Short.MAX_VALUE);
-            if (!key.equals("INFO")) {
-                return;
+            if (e.getTag().equals("LMC") || e.getTag().equals("labymod3:main")) {
+                ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
+                String key = StringUtils.readString(buf, Short.MAX_VALUE);
+                if (!key.equals("INFO")) {
+                    return;
+                }
+                String json = StringUtils.readString(buf, Short.MAX_VALUE);
+                Document data = Document.parse(json);
+                String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
+
+                task.addData("labymod:" + version);
+            } else {
+                task.addData(new String(e.getData()));
             }
-            String json = StringUtils.readString(buf, Short.MAX_VALUE);
-            Document data = Document.parse(json);
-            String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
 
-            task.addData("labymod:" + version);
+            TEMP_CACHE.put(player.getUniqueId(), System.currentTimeMillis());
+            v4GuardBungee.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
         }
-
-        TEMP_CACHE.put(player.getUniqueId(), System.currentTimeMillis());
-        v4GuardBungee.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
     }
 }

--- a/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
+++ b/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
@@ -1,8 +1,11 @@
 package io.v4guard.plugin.bungee.listener;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.v4guard.plugin.bungee.v4GuardBungee;
+import io.v4guard.plugin.core.socket.SocketStatus;
 import io.v4guard.plugin.core.tasks.types.CompletableMCBrandTask;
 import io.v4guard.plugin.core.utils.StringUtils;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -11,39 +14,54 @@ import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import org.bson.Document;
 
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 public class PluginMessagingListener implements Listener {
+
+
+    private final Cache<UUID, Long> TEMP_CACHE = Caffeine
+            .newBuilder()
+            .expireAfterWrite(1, TimeUnit.SECONDS)
+            .build();
+
 
     public PluginMessagingListener() {
         v4GuardBungee.getV4Guard().getProxy().getPluginManager().registerListener(v4GuardBungee.getV4Guard(), this);
     }
 
     @EventHandler
-    public void onChannelMessage(PluginMessageEvent e){
+    public void onChannelMessage(PluginMessageEvent e) {
+        if (v4GuardBungee.getCoreInstance().getBackendConnector().getSocketStatus() != SocketStatus.AUTHENTICATED) return;
+        if (!(e.getSender() instanceof ProxiedPlayer)) return;
+
+        ProxiedPlayer player = (ProxiedPlayer) e.getSender();
+        if (v4GuardBungee.getCoreInstance().getBrandCheckManager().isPlayerAlreadyChecked(player.getUniqueId()) && !TEMP_CACHE.asMap().containsKey(player.getUniqueId())) return;
 
         Document privacySettings = (Document) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("privacy", new Document());
         boolean invalidatedCache = (boolean) v4GuardBungee.getCoreInstance().getBackendConnector().getSettings().getOrDefault("invalidateCache", false);
-        if(!invalidatedCache && privacySettings.getBoolean("collectMCBrand", true)){
-            if(e.getSender() instanceof ProxiedPlayer){
-                if(e.getTag().equals("MC|Brand") || e.getTag().equals("minecraft:brand")){
-                    ProxiedPlayer player = (ProxiedPlayer) e.getSender();
-                    CompletableMCBrandTask task = v4GuardBungee.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getName());
-                    if(task == null) task = new CompletableMCBrandTask(player.getName());
-                    task.addData(new String(e.getData()));
-                } else if (e.getTag().equals("LMC") || e.getTag().equals("labymod3:main")){
-                    ProxiedPlayer player = (ProxiedPlayer) e.getSender();
-                    CompletableMCBrandTask task = v4GuardBungee.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getName());
-                    if(task == null) task = new CompletableMCBrandTask(player.getName());
-                    ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
-                    String key = StringUtils.readString(buf, Short.MAX_VALUE);
-                    if(!key.equals("INFO")){
-                        return;
-                    }
-                    String json = StringUtils.readString(buf, Short.MAX_VALUE);
-                    Document data = Document.parse(json);
-                    String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
-                    task.addData("labymod:" + version);
-                }
+
+        if (invalidatedCache && !privacySettings.getBoolean("collectMCBrand", true)) return;
+
+        CompletableMCBrandTask task = v4GuardBungee.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getName());
+        if (task == null) task = new CompletableMCBrandTask(player.getName());
+
+        if (e.getTag().equals("MC|Brand") || e.getTag().equals("minecraft:brand")) {
+            task.addData(new String(e.getData()));
+        } else if (e.getTag().equals("LMC") || e.getTag().equals("labymod3:main")) {
+            ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
+            String key = StringUtils.readString(buf, Short.MAX_VALUE);
+            if (!key.equals("INFO")) {
+                return;
             }
+            String json = StringUtils.readString(buf, Short.MAX_VALUE);
+            Document data = Document.parse(json);
+            String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
+
+            task.addData("labymod:" + version);
         }
+
+        TEMP_CACHE.put(player.getUniqueId(), System.currentTimeMillis());
+        v4GuardBungee.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
     }
 }

--- a/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
+++ b/src/main/java/io/v4guard/plugin/bungee/listener/PluginMessagingListener.java
@@ -8,7 +8,9 @@ import io.v4guard.plugin.bungee.v4GuardBungee;
 import io.v4guard.plugin.core.socket.SocketStatus;
 import io.v4guard.plugin.core.tasks.types.CompletableMCBrandTask;
 import io.v4guard.plugin.core.utils.StringUtils;
+import io.v4guard.plugin.core.v4GuardCore;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
@@ -65,5 +67,10 @@ public class PluginMessagingListener implements Listener {
             TEMP_CACHE.put(player.getUniqueId(), System.currentTimeMillis());
             v4GuardBungee.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
         }
+    }
+
+    @EventHandler
+    public void onPlayerDisconnect(PlayerDisconnectEvent event) {
+        v4GuardCore.getInstance().getBrandCheckManager().removePlayer(event.getPlayer().getUniqueId());
     }
 }

--- a/src/main/java/io/v4guard/plugin/core/brand/BrandCheckManager.java
+++ b/src/main/java/io/v4guard/plugin/core/brand/BrandCheckManager.java
@@ -1,0 +1,26 @@
+package io.v4guard.plugin.core.brand;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class BrandCheckManager {
+
+    private final Set<UUID> playerCheckedSet;
+
+    public BrandCheckManager() {
+        this.playerCheckedSet = new HashSet<>();
+    }
+
+    public void addPlayer(UUID playerUUID) {
+        playerCheckedSet.add(playerUUID);
+    }
+
+    public Boolean isPlayerAlreadyChecked(UUID playerUUID) {
+        return playerCheckedSet.contains(playerUUID);
+    }
+
+    public void removePlayer(UUID playerUUID) {
+        playerCheckedSet.remove(playerUUID);
+    }
+}

--- a/src/main/java/io/v4guard/plugin/core/tasks/types/CompletableMCBrandTask.java
+++ b/src/main/java/io/v4guard/plugin/core/tasks/types/CompletableMCBrandTask.java
@@ -1,6 +1,5 @@
 package io.v4guard.plugin.core.tasks.types;
 
-import io.v4guard.plugin.bungee.v4GuardBungee;
 import io.v4guard.plugin.core.tasks.common.CompletableTask;
 import io.v4guard.plugin.core.v4GuardCore;
 import org.bson.Document;
@@ -31,7 +30,7 @@ public class CompletableMCBrandTask implements CompletableTask {
         Document data = new Document();
         data.put("username", username);
         data.put("brand", brands);
-        v4GuardBungee.getCoreInstance().getBackendConnector().getSocket().emit("mc:brand", data.toJson());
+        v4GuardCore.getInstance().getBackendConnector().getSocket().emit("mc:brand", data.toJson());
         v4GuardCore.getInstance().getCompletableTaskManager().getTasks().remove(taskID);
     }
 

--- a/src/main/java/io/v4guard/plugin/core/v4GuardCore.java
+++ b/src/main/java/io/v4guard/plugin/core/v4GuardCore.java
@@ -1,7 +1,7 @@
 package io.v4guard.plugin.core;
 
 import io.v4guard.plugin.core.accounts.AccountShieldManager;
-import io.v4guard.plugin.core.chatfilter.ChatFilterManager;
+import io.v4guard.plugin.core.brand.BrandCheckManager;
 import io.v4guard.plugin.core.check.CheckManager;
 import io.v4guard.plugin.core.mode.v4GuardMode;
 import io.v4guard.plugin.core.socket.BackendConnector;
@@ -18,11 +18,11 @@ public class v4GuardCore {
     private static v4GuardCore INSTANCE;
     private final File folder;
 
-    private CompletableTaskManager completableTaskManager;
-    private BackendConnector backendConnector;
-    private CheckManager checkManager;
+    private final CompletableTaskManager completableTaskManager;
+    private final BackendConnector backendConnector;
+    private final CheckManager checkManager;
+    private final BrandCheckManager brandCheckManager;
     private AccountShieldManager accountShieldManager;
-    private ChatFilterManager chatFilterManager;
 
     public static final String pluginVersion = "1.1.4";
 
@@ -53,8 +53,7 @@ public class v4GuardCore {
         this.completableTaskManager = new CompletableTaskManager();
         this.backendConnector = new BackendConnector();
         this.checkManager = new CheckManager();
-        //this.chatFilterManager = new ChatFilterManager();
-
+        this.brandCheckManager = new BrandCheckManager();
     }
 
     public boolean isAccountShieldFound() {
@@ -73,10 +72,6 @@ public class v4GuardCore {
         return folder;
     }
 
-    public ChatFilterManager getChatFilterManager() {
-        return chatFilterManager;
-    }
-
     public CompletableTaskManager getCompletableTaskManager() {
         return completableTaskManager;
     }
@@ -88,6 +83,8 @@ public class v4GuardCore {
     public CheckManager getCheckManager() {
         return checkManager;
     }
+
+    public BrandCheckManager getBrandCheckManager() { return brandCheckManager; }
 
     public static v4GuardCore getInstance() {
         return INSTANCE;

--- a/src/main/java/io/v4guard/plugin/velocity/listener/PlayerBrandListener.java
+++ b/src/main/java/io/v4guard/plugin/velocity/listener/PlayerBrandListener.java
@@ -15,8 +15,8 @@ public class PlayerBrandListener {
 
     @Subscribe(order = PostOrder.FIRST)
     public void onPlayerServerBrand(PlayerClientBrandEvent e, Continuation continuation) {
-        if (e.getBrand().equalsIgnoreCase("labbymod")) return;
-
+        if (e.getBrand().equalsIgnoreCase("labymod")) return;
+        
         Player player = e.getPlayer();
         if (v4GuardVelocity.getCoreInstance().getBrandCheckManager().isPlayerAlreadyChecked(player.getUniqueId())) return;
 

--- a/src/main/java/io/v4guard/plugin/velocity/listener/PluginMessagingListener.java
+++ b/src/main/java/io/v4guard/plugin/velocity/listener/PluginMessagingListener.java
@@ -1,6 +1,5 @@
 package io.v4guard.plugin.velocity.listener;
 
-import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.proxy.Player;
@@ -14,33 +13,34 @@ import org.bson.Document;
 
 public class PluginMessagingListener {
 
-    @Subscribe(order = PostOrder.FIRST)
-    public void onMessage(PluginMessageEvent e){
+    @Subscribe
+    public void onMessage(PluginMessageEvent e) {
         if (v4GuardVelocity.getCoreInstance().getBackendConnector().getSocketStatus() != SocketStatus.AUTHENTICATED) return;
         if (!(e.getSource() instanceof Player)) return;
 
         Player player = (Player) e.getSource();
         if (v4GuardVelocity.getCoreInstance().getBrandCheckManager().isPlayerAlreadyChecked(player.getUniqueId())) return;
-        if (!(e.getIdentifier().getId().equals("LMC") || e.getIdentifier().getId().equals("labymod3:main"))) return;
 
-        Document privacySettings = (Document) v4GuardVelocity.getCoreInstance().getBackendConnector().getSettings().getOrDefault("privacy", new Document());
-        boolean invalidatedCache = (boolean) v4GuardVelocity.getCoreInstance().getBackendConnector().getSettings().getOrDefault("invalidateCache", false);
+        if (e.getIdentifier().getId().equals("LMC") || e.getIdentifier().getId().equals("labymod3:main")) {
+            Document privacySettings = (Document) v4GuardVelocity.getCoreInstance().getBackendConnector().getSettings().getOrDefault("privacy", new Document());
+            boolean invalidatedCache = (boolean) v4GuardVelocity.getCoreInstance().getBackendConnector().getSettings().getOrDefault("invalidateCache", false);
 
-        if (invalidatedCache && !privacySettings.getBoolean("collectMCBrand", true)) return;
+            if (invalidatedCache && !privacySettings.getBoolean("collectMCBrand", true)) return;
 
-        CompletableMCBrandTask task = v4GuardVelocity.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getUsername());
-        if(task == null) task = new CompletableMCBrandTask(player.getUsername());
+            CompletableMCBrandTask task = v4GuardVelocity.getCoreInstance().getCompletableTaskManager().getBrandTask(player.getUsername());
+            if(task == null) task = new CompletableMCBrandTask(player.getUsername());
 
-        ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
-        String key = StringUtils.readString(buf, Short.MAX_VALUE);
-        if(!key.equals("INFO")){
-            return;
+            ByteBuf buf = Unpooled.wrappedBuffer(e.getData());
+            String key = StringUtils.readString(buf, Short.MAX_VALUE);
+            if(!key.equals("INFO")){
+                return;
+            }
+
+            String json = StringUtils.readString(buf, Short.MAX_VALUE);
+            Document data = Document.parse(json);
+            String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
+            task.addData("labymod:" + version);
+            v4GuardVelocity.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
         }
-
-        String json = StringUtils.readString(buf, Short.MAX_VALUE);
-        Document data = Document.parse(json);
-        String version = data == null ? "unknown" : (String) data.getOrDefault("version", "unknown");
-        task.addData("labymod:" + version);
-        v4GuardVelocity.getCoreInstance().getBrandCheckManager().addPlayer(player.getUniqueId());
     }
 }

--- a/src/main/java/io/v4guard/plugin/velocity/v4GuardVelocity.java
+++ b/src/main/java/io/v4guard/plugin/velocity/v4GuardVelocity.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import io.v4guard.plugin.core.accounts.AccountShieldManager;
 import io.v4guard.plugin.core.mode.v4GuardMode;
 import io.v4guard.plugin.core.v4GuardCore;
@@ -75,6 +76,10 @@ public class v4GuardVelocity {
             return;
         }
         v4GuardVelocity = this;
+
+        server.getChannelRegistrar().register(MinecraftChannelIdentifier.from("labymod3:main"));
+        server.getChannelRegistrar().register(MinecraftChannelIdentifier.create("labymod3", "main"));
+
         server.getEventManager().register(this, new AntiVPNListener());
         server.getEventManager().register(this, new PluginMessagingListener());
         server.getEventManager().register(this, new PlayerBrandListener());

--- a/src/main/java/io/v4guard/plugin/velocity/v4GuardVelocity.java
+++ b/src/main/java/io/v4guard/plugin/velocity/v4GuardVelocity.java
@@ -12,6 +12,7 @@ import io.v4guard.plugin.core.mode.v4GuardMode;
 import io.v4guard.plugin.core.v4GuardCore;
 import io.v4guard.plugin.velocity.accounts.VelocityMessageReceiver;
 import io.v4guard.plugin.velocity.listener.AntiVPNListener;
+import io.v4guard.plugin.velocity.listener.PlayerBrandListener;
 import io.v4guard.plugin.velocity.listener.PluginMessagingListener;
 import io.v4guard.plugin.velocity.messager.Messager;
 import net.kyori.adventure.text.Component;
@@ -76,6 +77,7 @@ public class v4GuardVelocity {
         v4GuardVelocity = this;
         server.getEventManager().register(this, new AntiVPNListener());
         server.getEventManager().register(this, new PluginMessagingListener());
+        server.getEventManager().register(this, new PlayerBrandListener());
         server.getConsoleCommandSource().sendMessage(
                 Component.text("§e[v4guard-plugin] (Velocity) Enabling... [DONE]")
         );


### PR DESCRIPTION
This pull request is aimed at the client brand collection of the plugin.

Principally fixes:
- Errors when using Velocity and having the client brand collection enabled [Image](https://i.imgur.com/AJFNxQe.png)
- Fixes constant send of Minecraft Brand when the player switches servers. 
- Fixed collecting brands on Velocity.