### PR TITLE
Fix CME when listening to Minecraft client branding

### DIFF
--- a/src/main/java/io/v4guard/plugin/core/tasks/CompletableTaskManager.java
+++ b/src/main/java/io/v4guard/plugin/core/tasks/CompletableTaskManager.java
@@ -4,12 +4,14 @@ import io.v4guard.plugin.core.tasks.common.CompletableTask;
 import io.v4guard.plugin.core.tasks.types.CompletableMCBrandTask;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CompletableTaskManager {
 
-    private HashMap<String, CompletableTask> tasks = new HashMap<>();
+    private final Map<String, CompletableTask> tasks = new ConcurrentHashMap<>();
 
-    public HashMap<String, CompletableTask> getTasks() {
+    public Map<String, CompletableTask> getTasks() {
         return this.tasks;
     }
 

--- a/src/main/java/io/v4guard/plugin/core/tasks/CompletableTaskManager.java
+++ b/src/main/java/io/v4guard/plugin/core/tasks/CompletableTaskManager.java
@@ -3,7 +3,6 @@ package io.v4guard.plugin.core.tasks;
 import io.v4guard.plugin.core.tasks.common.CompletableTask;
 import io.v4guard.plugin.core.tasks.types.CompletableMCBrandTask;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 


### PR DESCRIPTION
This PR aims to fix a ConcurrentModificationException when listening to the client brand. ([See error here](https://pastebin.com/EkVEuDcj))

The fix is quite simple. It changes the object type from HashMap to ConcurrentHashMap, thus fixing the CME.